### PR TITLE
Allocations: ESFA statement with tabs

### DIFF
--- a/app/views/Allocation-statements/Adult-allocation-statements/allocation-history/esfa-adult-skills-fund-grants-contracts-history.html
+++ b/app/views/Allocation-statements/Adult-allocation-statements/allocation-history/esfa-adult-skills-fund-grants-contracts-history.html
@@ -1,0 +1,106 @@
+{% extends "layouts/main.html" %}
+ 
+{% set pageName="Allocation history" %}
+ 
+{% block content %}
+<!-- Phase banner -->
+<div class="govuk-phase-banner">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <p class="govuk-phase-banner__content">
+            <span class="govuk-phase-banner__text">Viewing as Trn (Train) Ltd. (UKPRN: 10000082) </span>
+          </p>
+        </div>
+        <div class="govuk-grid-column-one-third">
+          <p class="govuk-phase-banner__content">
+            <span class="govuk-link govuk-!-padding-right-4"><a href="view-your-roles">View your sub-services</a></span>
+            <span class="govuk-link"><a href="#" >Sign out</a></span>
+          </p>
+        </div>
+    </div>
+   </div>
+<!-- Pahse banner end -->
+    <div class="govuk-breadcrumbs">
+        <ol class="govuk-breadcrumbs__list">
+          <li class="govuk-breadcrumbs__list-item">
+            <a class="govuk-breadcrumbs__link" href="../allocation-dashboard.html">Home</a>
+          </li>
+          <li class="govuk-breadcrumbs__list-item">
+            <a class="govuk-breadcrumbs__link" href="../choose-statement-type.html">Choose a statement type</a>
+          </li>
+          <li class="govuk-breadcrumbs__list-item">
+            <a class="govuk-breadcrumbs__link" href="../statement-list-page.html">19+ Allocation statements</a>
+          </li>
+          <li class="govuk-breadcrumbs__list-item">Allocation history
+          </ol>
+    </div>
+    <main class="govuk-main-wrapper">
+      <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+            <h1 class="govuk-heading-l govuk-!-padding-top-6"><span class="govuk-caption-xl">ESFA adult skills fund </span>Allocation history</h1>
+            <p class="govuk-body govuk-!-font-size-24">View detailed breakdowns of ESFA adult skills fund for each academic year.</p>
+            </div>
+      </div>
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <table class="govuk-table">
+                    <caption class="govuk-table__caption govuk-table__caption--m govuk-!-padding-top-6">AY 2024 to 2025</caption>
+                    <thead class="govuk-table__head">
+                      <tr class="govuk-table__row">
+                        <th scope="col" class="govuk-table__header">Published</th>
+                        <th scope="col" class="govuk-table__header govuk-!-padding-right-7">Version</th>
+                      </tr>
+                    </thead>
+                    <tbody class="govuk-table__body">
+                      <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header govuk-!-font-weight-regular"><a class="govuk-link govuk-!-padding-right-1" href="../statement-pages/esfa-adult-skills-fund-tab.html" >6 July 2024 </a> 
+                          <strong class="govuk-tag">
+                            Latest
+                          </strong></th>
+                        <td class="govuk-table__cell">Version 2</td>
+                      </tr>  
+                      <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header govuk-!-font-weight-regular"><a class="govuk-link" href="./statement-pages/esfa-adult-skills-fund-grant.html" >26 March 2024 </a> 
+                          </th>
+                        <td class="govuk-table__cell">Version 1</td>
+                      </tr>                  
+                    </tbody>
+                </table>
+                <table class="govuk-table">
+                  <caption class="govuk-table__caption govuk-table__caption--m">AY 2023 to 2024</caption>
+                  <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                      <th scope="col" class="govuk-table__header">Published</th>
+                      <th scope="col" class="govuk-table__header">Version</th>
+                    </tr>
+                  </thead>
+                  <tbody class="govuk-table__body">
+                    <tr class="govuk-table__row">
+                      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular"><a class="govuk-link" href="#" >6 July 2023 </a></th>
+                      <td class="govuk-table__cell">Version 2</td>
+                    </tr>
+                    <tr class="govuk-table__row">
+                      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular"><a class="govuk-link" href="#" >31 March 2023 </a></th>
+                      <td class="govuk-table__cell">Version 1</td>
+                    </tr>
+                  </tbody>
+              </table>
+              <table class="govuk-table">
+                <caption class="govuk-table__caption govuk-table__caption--m">AY 2022 to 2023</caption>
+                <thead class="govuk-table__head">
+                  <tr class="govuk-table__row">
+                    <th scope="col" class="govuk-table__header">Published</th>
+                    <th scope="col" class="govuk-table__header govuk-!-padding-right-2">Version</th>
+                  </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                  <tr class="govuk-table__row">
+                    <th scope="row" class="govuk-table__header govuk-!-font-weight-regular"><a class="govuk-link" href="#" >31 March 2022 </a> </th>
+                    <td class="govuk-table__cell">Version 1</td>
+                  </tr>
+                </tbody>
+            </table>
+            </div>
+      </div>
+    </main>
+{% endblock %}

--- a/app/views/Allocation-statements/Adult-allocation-statements/statement-list-page.html
+++ b/app/views/Allocation-statements/Adult-allocation-statements/statement-list-page.html
@@ -55,13 +55,13 @@
                                 <div id="accordion-default-content-1" class="govuk-accordion__section-content">
                                     <h2 class="govuk-heading-s">Funding breakdown</h2>
                                     <p class="govuk-body">
-                                        <a href="./statement-pages/esfa-adult-skills-fund-grant.html" class="govuk-link">
+                                        <a href="./statement-pages/esfa-adult-skills-fund-tab.html" class="govuk-link">
                                             View ESFA adult skills fund </a>
                                     </p>
                                     <h2 class="govuk-heading-s">Allocation history</h2>
                                     <p class="govuk-body">
-                                        <a href="./allocation-history/esfa-adult-skills-fund-grant-history.html" class="govuk-link">View history of allocated funding</a>
-                                    </p>          
+                                        <a href="./allocation-history/esfa-adult-skills-fund-grants-contracts-history.html" class="govuk-link">View history of allocated funding</a>
+                                    </p>
                                     <h2 class="govuk-heading-s">Explore the topic</h2>
                                     <p class="govuk-body">
                                         <a href=" https://www.gov.uk/guidance/19-funding-allocations" target=”_blank” class="govuk-link">ESFA 19+ funding allocation guides : 2024 to 2025 (opens in new tab)</a>

--- a/app/views/Allocation-statements/Adult-allocation-statements/statement-pages/esfa-adult-skills-fund-tab.html
+++ b/app/views/Allocation-statements/Adult-allocation-statements/statement-pages/esfa-adult-skills-fund-tab.html
@@ -186,7 +186,7 @@
                     <div class="govuk-grid-row govuk-!-padding-left-5 govuk-!-padding-top-6"> 
                       <h2 class="govuk-heading-m">Allocation history</h2>
                       <p class="govuk-body">
-                        <a href="../allocation-history/esfa-adult-skills-fund-grant-history.html" class="govuk-link">View history of allocated funding</a>
+                        <a href="../allocation-history/esfa-adult-skills-fund-grants-contracts-history.html" class="govuk-link">View history of allocated funding</a>
                       </p>
                       <h2 class="govuk-heading-m">Explore the topic</h2>
                       <p class="govuk-body">
@@ -318,7 +318,7 @@
                     <div class="govuk-grid-row govuk-!-padding-left-5 govuk-!-padding-top-6"> 
                       <h2 class="govuk-heading-m">Allocation history</h2>
                       <p class="govuk-body">
-                        <a href="../allocation-history/esfa-adult-skills-fund-contract-history.html" class="govuk-link">View history of allocated funding</a>
+                        <a href="../allocation-history/esfa-adult-skills-fund-grants-contracts-history.html" class="govuk-link">View history of allocated funding</a>
                       </p>
                       <h2 class="govuk-heading-m">Explore the topic</h2>
                       <p class="govuk-body">


### PR DESCRIPTION
Cloning the existing ESFA history page so it accommodates for both 'Grants' and 'Contract for services' parts of the statement. These are now separated into two tabs on the same statement.

Redirecting the Statements list page 'View funding breakdown' link to the new ESFA adult statement with tabs.

Redirecting the 'View history of funding' link to the cloned history page (the URL ends in "esfa-adult-skills-fund-grants-contracts-history.html")

Within the new cloned ESFA history page, I've redirected the 6 July link to the new ESFA statement with the tabs.