### PR TITLE
Final prototype refinements from Figma

### DIFF
--- a/app/views/Allocation-statements/Adult-allocation-statements/allocation-history/nonlevy-apprenticeships-history.html
+++ b/app/views/Allocation-statements/Adult-allocation-statements/allocation-history/nonlevy-apprenticeships-history.html
@@ -76,7 +76,7 @@
                     </tr>
                   </tbody>
               </table>
-              <table class="govuk-table">
+             <!-- <table class="govuk-table">
                 <caption class="govuk-table__caption govuk-table__caption--m">AY 2022 to 2023</caption>
                 <thead class="govuk-table__head">
                   <tr class="govuk-table__row">
@@ -90,7 +90,7 @@
                     <td class="govuk-table__cell">Version 1</td>
                   </tr>
                 </tbody>
-            </table>
+            </table>-->
         </div>
       </div>
     </main>

--- a/app/views/Allocation-statements/Adult-allocation-statements/statement-list-page.html
+++ b/app/views/Allocation-statements/Adult-allocation-statements/statement-list-page.html
@@ -44,7 +44,7 @@
                                 <h2 class="govuk-accordion__section-heading">
                                     <a class="govuk-accordion__heading-text-left govuk-accordion__section-button " id="accordion-default-heading-5">
                                     ESFA adult skills fund for 2024 to 2025
-                                    <span class="govuk-accordion__heading-number-left" style="float: right;">£6,362,555</span>
+                                    <span class="govuk-accordion__heading-number-left" style="float: right;">£7,651,579</span>
                                     <span class="govuk-caption-m govuk-main-wrapper">Published: 6 July 2024. Version 2 
                                         <strong class="govuk-tag govuk-tag--blue"> Latest
                                         </strong>
@@ -64,7 +64,7 @@
                                     </p>          
                                     <h2 class="govuk-heading-s">Explore the topic</h2>
                                     <p class="govuk-body">
-                                        <a href=" https://www.gov.uk/guidance/19-funding-allocations" target=”_blank” class="govuk-link">ESFA 19+ funding allocation guides : 2024 to 2025 (opens in new tab)</a>
+                                        <a href=" https://www.gov.uk/guidance/19-funding-allocations" target=”_blank” class="govuk-link">ESFA 19+ funding allocation guides: 2024 to 2025 (opens in new tab)</a>
                                     </p>
                                 </div> 
                             </div>
@@ -95,7 +95,7 @@
                                     <h2 class="govuk-heading-s">Explore the topic</h2>
                                     <p class="govuk-body">
                                         <a href=" https://www.gov.uk/guidance/19-funding-allocations" class="govuk-link" target="_blank">
-                                            ESFA 19+ funding allocation guides : 2024 to 2025 (opens in new tab)</a>
+                                            ESFA 19+ funding allocation guides: 2024 to 2025 (opens in new tab)</a>
                                     </p>
                                     </div>         
                                 </div>
@@ -125,7 +125,7 @@
                                         </p>          
                                         <h2 class="govuk-heading-s">Explore the topic</h2>
                                         <p class="govuk-body">
-                                            <a href=" https://www.gov.uk/guidance/19-funding-allocations" target=”_blank” class="govuk-link">ESFA 19+ funding allocation guides : 2024 to 2025 (opens in new tab)</a>
+                                            <a href=" https://www.gov.uk/guidance/19-funding-allocations" target=”_blank” class="govuk-link">ESFA 19+ funding allocation guides: 2024 to 2025 (opens in new tab)</a>
                                         </p>
                                     </div> 
                                 </div>
@@ -155,7 +155,7 @@
                                         </p>          
                                         <h2 class="govuk-heading-s">Explore the topic</h2>
                                         <p class="govuk-body">
-                                            <a href=" https://www.gov.uk/guidance/19-funding-allocations" target=”_blank” class="govuk-link">ESFA 19+ funding allocation guides : 2024 to 2025 (opens in new tab)</a>
+                                            <a href=" https://www.gov.uk/guidance/19-funding-allocations" target=”_blank” class="govuk-link">ESFA 19+ funding allocation guides: 2024 to 2025 (opens in new tab)</a>
                                         </p>
                                     </div> 
                                 </div>
@@ -186,7 +186,7 @@
                                         </p>          
                                         <h2 class="govuk-heading-s">Explore the topic</h2>
                                         <p class="govuk-body">
-                                            <a href=" https://www.gov.uk/guidance/19-funding-allocations" target=”_blank” class="govuk-link">ESFA 19+ funding allocation guides : 2024 to 2025 (opens in new tab)</a>
+                                            <a href=" https://www.gov.uk/guidance/19-funding-allocations" target=”_blank” class="govuk-link">ESFA 19+ funding allocation guides: 2024 to 2025 (opens in new tab)</a>
                                         </p>
                                     </div> 
                                 </div>
@@ -217,7 +217,7 @@
                                             </p>          
                                             <h2 class="govuk-heading-s">Explore the topic</h2>
                                             <p class="govuk-body">
-                                                <a href=" https://www.gov.uk/guidance/19-funding-allocations" target=”_blank” class="govuk-link">ESFA 19+ funding allocation guides : 2024 to 2025 (opens in new tab)</a>
+                                                <a href=" https://www.gov.uk/guidance/19-funding-allocations" target=”_blank” class="govuk-link">ESFA 19+ funding allocation guides: 2024 to 2025 (opens in new tab)</a>
                                             </p>
                                         </div> 
                                     </div>

--- a/app/views/Allocation-statements/Adult-allocation-statements/statement-pages/advanced-leaner-loans.html
+++ b/app/views/Allocation-statements/Adult-allocation-statements/statement-pages/advanced-leaner-loans.html
@@ -70,7 +70,7 @@
                   <td class="govuk-table__cell align">£2,590</td>
                 </tr>
                 <tr class="govuk-table__row">
-                  <td class="govuk-table__cell">Total Advanced learner loans facility</td>
+                  <td class="govuk-table__cell">Total advanced learner loans facility</td>
                   <td class="govuk-table__cell align">£7,033</td>
                 </tr>
               </tbody>
@@ -95,7 +95,7 @@
                 <td class="govuk-table__cell align">£210</td>
               </tr>
               <tr class="govuk-table__row">
-                <td class="govuk-table__cell">Advanced learner loans bursary </td>
+                <td class="govuk-table__cell">Total advanced learner loans bursary </td>
                 <td class="govuk-table__cell align">£500</td>
               </tr>
             </tbody>


### PR DESCRIPTION
Refined the prototype for any last changes made in Figma so they match.

I’ve also hidden/commented out the Non-levy apprentice 2022 to 2023 table in the history view until we get confirmation of whether to show PDFs of not. If not then the history will only show 2023/2024 and 2024/2025 digital statements. If PDFs are in, then this table will be unhidden and designed to include the third column “Format”.