### PR TITLE
GAG IYO formatting changes

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -362,7 +362,7 @@ span.has-email-alerts span.text {
     vertical-align: middle;
 }
 h2 .variance-text {
-	font-size: 80% !important;
+	font-size: 70% !important;
     color:#d4351c;
 }
 td .variance-text {

--- a/app/views/General-annual-grant/indicative-statement-updated/indicative-comparison-statement.html
+++ b/app/views/General-annual-grant/indicative-statement-updated/indicative-comparison-statement.html
@@ -75,7 +75,7 @@
                   </div>
             </div>
             <div class="govuk-grid-column-full">
-                <h2 class="govuk-heading-l govuk-!-margin-bottom-0 govuk-!-font-weight-regular">Total allocation <span> (based on being open 123 days)</span></h2>
+                <h2 class="govuk-heading-m govuk-!-margin-bottom-0 govuk-!-font-weight-regular">Total allocation <span> (based on being open 123 days)</span></h2>
                 <h2 class="govuk-heading-l">£754,646.06
                   <!--variance format-->
                   <div class="govuk-!-padding-left-6">
@@ -109,7 +109,7 @@
                       </li>
                     </ul>
                     <div class="govuk-tabs__panel" id="sb">
-                      <h2 class="govuk-heading-l govuk-!-margin-bottom-0 govuk-!-font-weight-regular">Total school budget share</h2>
+                      <h2 class="govuk-heading-m govuk-!-margin-bottom-0 govuk-!-font-weight-regular">Total school budget share</h2>
                       <h2 class="govuk-heading-l govuk-!-padding-bottom-0">£676,888.09
                         <!--variance format-->
                         <div class="govuk-!-padding-left-3">
@@ -663,7 +663,7 @@
 
                     <!--Minimum funding guarentee-->
                     <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="mfg">
-                      <h2 class="govuk-heading-l govuk-!-margin-bottom-0 govuk-!-font-weight-regular">Total minimum funding guarantee</h2>
+                      <h2 class="govuk-heading-m govuk-!-margin-bottom-0 govuk-!-font-weight-regular">Total minimum funding guarantee</h2>
                       <h2 class="govuk-heading-l">£9,007.97
                            <!--variance format-->
                            <p id="DecreasedByVariance"  class="variance-hidden-text"aria-label="Decreased by">Decreased by</p>
@@ -801,7 +801,7 @@
                     </div>
                     <!--Start-up grant-->
                     <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="sg">
-                      <h2 class="govuk-heading-l govuk-!-margin-bottom-0 govuk-!-font-weight-regular">Total start-up grant for new academy</h2>
+                      <h2 class="govuk-heading-m govuk-!-margin-bottom-0 govuk-!-font-weight-regular">Total start-up grant for new academy</h2>
                       <h2 class="govuk-heading-l">£68,750.00</h2>
                       <table class="govuk-table">
                         <caption class="govuk-table__caption govuk-table__caption--m govuk-!-padding-top-4 govuk-!-padding-bottom-2">Start-up grant</caption>

--- a/app/views/General-annual-grant/indicative-statement-updated/indicative-nocomparison-statement.html
+++ b/app/views/General-annual-grant/indicative-statement-updated/indicative-nocomparison-statement.html
@@ -74,7 +74,7 @@
                   </div>
             </div>
             <div class="govuk-grid-column-full">
-                <h2 class="govuk-heading-l govuk-!-margin-bottom-0 govuk-!-font-weight-regular">Total allocation <span>(based on being open 123 days)</span></h2>
+                <h2 class="govuk-heading-m govuk-!-margin-bottom-0 govuk-!-font-weight-regular">Total allocation <span>(based on being open 123 days)</span></h2>
                 <h2 class="govuk-heading-l">£754,646.06</h2>
             </div>
             <div class="govuk-grid-column-full">
@@ -100,7 +100,7 @@
                       </li>
                     </ul>
                     <div class="govuk-tabs__panel" id="sb">
-                      <h2 class="govuk-heading-l govuk-!-margin-bottom-0 govuk-!-font-weight-regular">Total school budget share</h2>
+                      <h2 class="govuk-heading-m govuk-!-margin-bottom-0 govuk-!-font-weight-regular">Total school budget share</h2>
                       <h2 class="govuk-heading-l govuk-!-margin-bottom-8">£676,888.09</h2>
                       <h2 class="govuk-heading-l govuk-!-margin-bottom-4 govuk-!-font-weight-bold">Pupil-led factors</h2>
 
@@ -520,7 +520,7 @@
                     </div>
                     <!--Minimum funding guarantee-->
                     <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="mfg">
-                      <h2 class="govuk-heading-l govuk-!-margin-bottom-0 govuk-!-font-weight-regular">Total minimum funding guarantee</h2>
+                      <h2 class="govuk-heading-m govuk-!-margin-bottom-0 govuk-!-font-weight-regular">Total minimum funding guarantee</h2>
                       <h2 class="govuk-heading-l">£9,007.97</h2>
                       <div class="govuk-inset-text">To calculate your indicative
                         <a href="https://www.gov.uk/government/publications/academies-general-annual-grant-allocation-guides-2024-to-2025/academy-general-annual-grant-allocation-guide-2024-to-2025-academic-year#minimum-funding-guarantee-mfg:~:text=MFG%C2%A0section.-,Minimum%20funding%20guarantee%20(MFG),-This%20section%20is" class="govuk-link" rel="noreferrer noopener" target="_blank"> minimum funding guarantee (opens in new tab)</a>.
@@ -622,7 +622,7 @@
                     </div>
                     <!--Start-up grant-->
                     <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="sg">
-                      <h2 class="govuk-heading-l govuk-!-margin-bottom-0 govuk-!-font-weight-regular">Total start-up grant for new academy</h2>
+                      <h2 class="govuk-heading-m govuk-!-margin-bottom-0 govuk-!-font-weight-regular">Total start-up grant for new academy</h2>
                       <h2 class="govuk-heading-l">£68,750.00</h2>
                       <table class="govuk-table">
                         <caption class="govuk-table__caption govuk-table__caption--m govuk-!-padding-top-4 govuk-!-padding-bottom-2">Start-up grant</caption>


### PR DESCRIPTION
Changed 'total allocation (based on being open [xxx] day' to a smaller font, and reduced the size of the main variances on the totals to 70% from 80%.